### PR TITLE
Fix: include final year of loan payments in simulation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1875,7 +1875,7 @@ function simulateStrategy(fixed, housePrice, initialDeposit, loanTerm, monthlyRE
       }
 
       // If loan is still active, amortize it
-      if (y < loanTerm && loanBalance > 0) {
+      if (y <= loanTerm && loanBalance > 0) {
         // Calculate annual payments and interest
         let totalAnnualPayment = monthlyRE * 12;
         let annualInterest = loanBalance * (fixed.interestRate/100);


### PR DESCRIPTION
## Problem

The loan payment simulation was skipping the final year of payments.

For a 25-year loan (`loanTerm=25`), the condition `y < loanTerm` only processed years 1-24, because `25 < 25` evaluates to `false`. This meant:

- Only 24 years of loan payments were being calculated instead of 25
- The loan balance was being set to 0 prematurely
- Net worth in the final years was slightly higher than it should be

## Fix

Changed the condition from `y < loanTerm` to `y <= loanTerm` so all loan payment years are processed correctly.

## Impact

This fix ensures the simulation accurately reflects the full loan term, giving more accurate net worth projections especially in the years around when the loan ends.